### PR TITLE
Fix generator to use filepath instead of path

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"text/template"
 
 	"golang.org/x/text/cases"
@@ -42,7 +42,7 @@ func main() {
 		})
 	}
 
-	tmpl, err := template.ParseGlob(path.Join("generator", "*.tpl"))
+	tmpl, err := template.ParseGlob(filepath.Join("generator", "*.tpl"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fix https://github.com/cohesivestack/valgo/issues/9

`filepath` support forward slashes or backslashes as filename separators.