### PR TITLE
Make `validationFactory` type public

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ We welcome pull requests for adding new locale messages, but please ensure that 
 
 Valgo provides the `Factory()` function which allows you to create a valgo factory. With a valgo factory, you can create `Validation` sessions with preset options, avoiding having to pass options each time when a Validation is created. This allows more flexibility and easier management of options when creating `Validation` sessions.
 
-The `Factory` function takes a parameter of type `FactoryOptions` struct, which allows you to modify the default locale code, add new locales, and set a custom JSON marshaler for errors. The `factory` instance created by this function has all the functions to create Validations available in the package level (`Is()`, `In()`, `Check()`, `New()`) which creates a new Validation session with the preset options in the factory.
+The `Factory` function takes a parameter of type `FactoryOptions` struct, which allows you to modify the default locale code, add new locales, and set a custom JSON marshaler for errors. The `ValidationFactory` instance created by this function has all the functions to create Validations available in the package level (`Is()`, `In()`, `Check()`, `New()`) which creates a new Validation session with the preset options in the factory.
 
 In the following example, we create a `Factory` with the default locale code set to Spanish, a new locale added for Estonian. This factory instance enables us to create validation sessions.
 

--- a/factory.go
+++ b/factory.go
@@ -12,7 +12,7 @@ type FactoryOptions struct {
 	MarshalJsonFunc func(e *Error) ([]byte, error)
 }
 
-type validationFactory struct {
+type ValidationFactory struct {
 	localeCodeDefault string
 	locales           map[string]*Locale
 	marshalJsonFunc   func(e *Error) ([]byte, error)
@@ -24,7 +24,7 @@ type validationFactory struct {
 //
 // The function is similar to the [New()] function, but it uses a factory.
 // For more information see the [New()] function.
-func (_factory *validationFactory) New(options ...Options) *Validation {
+func (_factory *ValidationFactory) New(options ...Options) *Validation {
 
 	var _options *Options
 	finalOptions := Options{
@@ -59,7 +59,7 @@ func (_factory *validationFactory) New(options ...Options) *Validation {
 //
 // The function is similar to the [Is()] function, but it uses a factory.
 // For more information see the [Is()] function.
-func (_factory *validationFactory) Is(v Validator) *Validation {
+func (_factory *ValidationFactory) Is(v Validator) *Validation {
 	return _factory.New().Is(v)
 }
 
@@ -69,7 +69,7 @@ func (_factory *validationFactory) Is(v Validator) *Validation {
 //
 // The function is similar to the [In()] function, but it uses a factory.
 // For more information see the [In()] function.
-func (_factory *validationFactory) In(name string, v *Validation) *Validation {
+func (_factory *ValidationFactory) In(name string, v *Validation) *Validation {
 	return _factory.New().In(name, v)
 }
 
@@ -80,7 +80,7 @@ func (_factory *validationFactory) In(name string, v *Validation) *Validation {
 //
 // The function is similar to the [InRow()] function, but it uses a factory.
 // For more information see the [InRow()] function.
-func (_factory *validationFactory) InRow(name string, index int, v *Validation) *Validation {
+func (_factory *ValidationFactory) InRow(name string, index int, v *Validation) *Validation {
 	return _factory.New().InRow(name, index, v)
 }
 
@@ -91,13 +91,13 @@ func (_factory *validationFactory) InRow(name string, index int, v *Validation) 
 //
 // The function is similar to the [Check()] function, but it uses a factory.
 // For more information see the [Check()] function.
-func (_factory *validationFactory) Check(v Validator) *Validation {
+func (_factory *ValidationFactory) Check(v Validator) *Validation {
 	return _factory.New().Check(v)
 }
 
 // Create a new [Validation] session, through a factory, and add an error
 // message to it without executing a field validator. By adding this error
 // message, the [Validation] session will be marked as invalid.
-func (_factory *validationFactory) AddErrorMessage(name string, message string) *Validation {
+func (_factory *ValidationFactory) AddErrorMessage(name string, message string) *Validation {
 	return _factory.New().AddErrorMessage(name, message)
 }

--- a/valgo.go
+++ b/valgo.go
@@ -19,9 +19,9 @@ package valgo
 // The Factory function accepts an options parameter of type [FactoryOptions]
 // struct, which allows you to specify options such as the default locale code,
 // available locales and a custom JSON marshaler for errors.
-func Factory(options FactoryOptions) *validationFactory {
+func Factory(options FactoryOptions) *ValidationFactory {
 
-	factory := &validationFactory{
+	factory := &ValidationFactory{
 		localeCodeDefault: localeCodeDefault,
 		marshalJsonFunc:   options.MarshalJsonFunc,
 	}


### PR DESCRIPTION
This PR updates the `validationFactory` type to be public by renaming it to `ValidationFactory`.

This change enhances flexibility and allows developers to reuse the factory more effectively in various scenarios.

By making it public, the `ValidationFactory` can now be utilized in external projects and libraries, promoting better code reuse and modularity.