### PR TITLE
fix: custom validation title

### DIFF
--- a/error.go
+++ b/error.go
@@ -73,7 +73,7 @@ func (ve *valueError) buildMessageFromTemplate(et *errorTemplate) string {
 	}
 
 	var title string
-	if ve.title == nil {
+	if ve.title == nil || *ve.title == "" {
 		title = humanizeName(*ve.name)
 	} else {
 		title = *ve.title

--- a/validation.go
+++ b/validation.go
@@ -136,7 +136,7 @@ func (v *Validation) AddErrorMessage(name string, message string) *Validation {
 
 	v.valid = false
 
-	ev := v.getOrCreateValueError(name)
+	ev := v.getOrCreateValueError(name, "")
 
 	ev.errorMessages = append(ev.errorMessages, message)
 
@@ -187,7 +187,7 @@ func (v *Validation) MergeErrorInRow(name string, index int, err *Error) *Valida
 	return v.mergeError(fmt.Sprintf("%s[%v]", name, index), err)
 }
 
-func (validation *Validation) invalidate(name *string, fragment *validatorFragment) {
+func (validation *Validation) invalidate(name *string, title *string, fragment *validatorFragment) {
 	if validation.errors == nil {
 		validation.errors = map[string]*valueError{}
 	}
@@ -201,7 +201,12 @@ func (validation *Validation) invalidate(name *string, fragment *validatorFragme
 		_name = *name
 	}
 
-	ev := validation.getOrCreateValueError(_name)
+	var _title string
+	if title != nil {
+		_title = *title
+	}
+
+	ev := validation.getOrCreateValueError(_name, _title)
 
 	errorKey := fragment.errorKey
 
@@ -249,10 +254,11 @@ func (validation *Validation) IsValid(name string) bool {
 	return true
 }
 
-func (validation *Validation) getOrCreateValueError(name string) *valueError {
+func (validation *Validation) getOrCreateValueError(name string, title string) *valueError {
 	if _, ok := validation.errors[name]; !ok {
 		validation.errors[name] = &valueError{
 			name:           &name,
+			title:          &title,
 			errorTemplates: map[string]*errorTemplate{},
 			errorMessages:  []string{},
 			validator:      validation,

--- a/validation_test.go
+++ b/validation_test.go
@@ -408,6 +408,36 @@ func TestValidationMergeErrorInRow(t *testing.T) {
 
 }
 
+func TestValidationCustomTitle(t *testing.T) {
+	v0 := Is(String("", "company_name").Not().Empty())
+
+	assert.False(t, v0.Valid())
+	assert.Equal(t,
+		"Company name can't be empty",
+		v0.Errors()["company_name"].Messages()[0])
+
+	v1 := Is(String("", "company_name", "Customer").Not().Empty())
+	assert.False(t, v1.Valid())
+	assert.Equal(t,
+		"Customer can't be empty",
+		v1.Errors()["company_name"].Messages()[0])
+}
+
+func TestValidationCustomTitlePanic(t *testing.T) {
+	v0 := Is(String("", "company_name").Not().Empty())
+	assert.False(t, v0.Valid())
+
+	if !v0.Valid() {
+		// calling valErr.Title() should not panic even if there is no
+		// custom title given
+		for _, valErr := range v0.Errors() {
+			assert.NotPanics(t, func() {
+				valErr.Title()
+			})
+		}
+	}
+}
+
 func ExampleValidation_Valid() {
 	val := Is(Number(21, "age").GreaterThan(18)).
 		Is(String("singl", "status").InSlice([]string{"married", "single"}))

--- a/validator_context.go
+++ b/validator_context.go
@@ -104,7 +104,7 @@ func (ctx *ValidatorContext) validate(validation *Validation, shortCircuit bool)
 
 		valid = fragment.function() == fragment.boolOperation && valid
 		if !valid {
-			validation.invalidate(ctx.name, fragment)
+			validation.invalidate(ctx.name, ctx.title, fragment)
 		}
 	}
 


### PR DESCRIPTION
Fixes the issue when custom title is set, the validation error message template using the generated title. 

Also fixes panic when calling Title() method on validation valueError when no custom title is set (now returns empty string instead).

One possible issue(?) may still be is, custom title can only be set once per field for a specific validator instance. But I assume, there aren't many cases where this would be needed.

```go
val := v.
  Is(v.String("", "company_name", "Business").Not().Blank()).
  Is(v.String("", "company_name", "Customer").OfLengthBetween(3, 10))

// output: instead of `Customer`, it stll uses `Business` for second error message
// {
//   "company_name": [
//     "Business can't be blank",
//     "Business must have a length between \"3\" and \"10\""
//   ]
// }

``` 