### PR TITLE
Add new `Or` operator function to Validators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Valgo is used in production by [Statsignal](https://statsignal.dev), but we want
   - [Time pointer validator](#time-pointer-validator)
   - [Any validator](#any-validator)
   - [Custom type validators](#custom-type-validators)
+- [Or Operator in Validators](#or-operator-in-validators)
+  - [Overview](#overview)
+  - [Usage](#usage)
+  - [Key Points](#key-points)
+  - [Examples](#examples)
 - [Extending Valgo with custom validators](#extending-valgo-with-custom-validators)
 - [List of rules by validator type](#list-of-rules-by-validator-type)
 - [Github Code Contribution Guide](#github-code-contribution-guide)
@@ -941,6 +946,51 @@ type Stage int64
 var stage Stage = 2
 val := v.Is(v.NumberP(&stage).GreaterThan(Stage(1)))
 ```
+
+# Or Operator in Validators
+
+The `Or` operator function enables developers to combine validator rules using a logical OR chain. This addition allows for more nuanced validator scenarios, where a value may satisfy one of multiple conditions to be considered valid.
+
+## Overview
+
+In Valgo, validator rules are typically chained together using an implicit AND logic. This means that for a value to be deemed valid, it must satisfy all specified conditions. The `Or` operator provides an alternative by allowing conditions to be linked with OR logic. In such cases, a value is considered valid if it meets at least one of the chained conditions.
+
+The `Or` operator follows a simple left-to-right boolean priority, akin to the Go language's approach to evaluating boolean expressions. Valgo does not have an equivalent to parentheses in API functions, in order to keep the syntax simple and readable. We believe that complex boolean logic becomes harder to read with a Fluent API interface, so for those cases, it is preferred to use imperative Go programming language constructs.
+
+## Usage
+
+To utilize the `Or` operator, simply insert `.Or().` between two conditions within your validator chain. Here's a basic example:
+
+```go
+v := Is(Bool(true).True().Or().False())
+```
+
+In this case, the validator passes because the boolean value `true` satisfies the first condition before the `Or()` operator.
+
+## Key Points
+
+- **Implicit AND Logic**: By default, when validators are chained without specifying the `Or()` operator, they are combined using an AND logic. Each condition must be met for the validation to pass.
+- **No Short-circuiting for `Check`**: Unlike the `Is` function, which evaluates conditions lazily and may short-circuit (stop evaluating once the overall outcome is determined), the `Check` function ensures that all conditions are evaluated, regardless of their order and the use of `Or`.
+
+## Examples
+
+Below are examples demonstrating different scenarios using the `Or` operator, including combinations with the `Not` operator and multiple `Or` conditions in sequence. These examples illustrate how you can tailor complex validation logic to suit your needs.
+
+```go
+// Validation with two valid OR conditions
+v = Is(Bool(true).True().Or().True())
+assert.True(t, v.Valid())
+
+// Validation with a valid OR condition followed by an invalid AND condition
+v = Is(Bool(true).False().Or().True().False())
+assert.False(t, v.Valid())
+
+// Validation combining NOT and OR operators
+v = Is(Bool(true).Not().False().Or().False())
+assert.True(t, v.Valid())
+```
+
+These examples are intended to provide a clear understanding of how to effectively use the `Or` operator in your validations. By leveraging this functionality, you can create more flexible and powerful validation rules, enhancing the robustness and usability of your applications.
 
 # Extending Valgo with custom validators
 

--- a/generator/validator_number.gen.go.tpl
+++ b/generator/validator_number.gen.go.tpl
@@ -69,6 +69,22 @@ func (validator *Validator{{ .Name }}[T]) Not() *Validator{{ .Name }}[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := {{ .Type }}(0)
+//	isValid := v.Is(v.{{ .Name }}(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *Validator{{ .Name }}[T]) Or() *Validator{{ .Name }}[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the {{ .Type }} value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/generator/validator_number_p.gen.go.tpl
+++ b/generator/validator_number_p.gen.go.tpl
@@ -38,6 +38,22 @@ func (validator *Validator{{ .Name }}P[T]) Not() *Validator{{ .Name }}P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := {{ .Type }}(0)
+//	isValid := v.Is(v.{{ .Name }}P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *Validator{{ .Name }}P[T]) Or() *Validator{{ .Name }}P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the {{ .Type }} pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/generator/validator_number_p_test.gen.go.tpl
+++ b/generator/validator_number_p_test.gen.go.tpl
@@ -598,4 +598,181 @@ func TestValidator{{ .Name }}PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidator{{ .Name }}POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = {{ .Type }}(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is({{ .Name }}P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is({{ .Name }}P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is({{ .Name }}P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is({{ .Name }}P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is({{ .Name }}P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidator{{ .Name }}POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = {{ .Type }}(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check({{ .Name }}P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check({{ .Name }}P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check({{ .Name }}P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check({{ .Name }}P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check({{ .Name }}P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check({{ .Name }}P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check({{ .Name }}P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 {{ end }}

--- a/generator/validator_number_test.gen.go.tpl
+++ b/generator/validator_number_test.gen.go.tpl
@@ -389,4 +389,178 @@ func TestValidator{{ .Name }}InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidator{{ .Name }}OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).Not().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is({{ .Name }}({{ .Type }}(1)).Not().EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidator{{ .Name }}OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).Not().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check({{ .Name }}({{ .Type }}(1)).Not().EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(1)).Or().EqualTo({{ .Type }}(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check({{ .Name }}({{ .Type }}(1)).EqualTo({{ .Type }}(1)).EqualTo({{ .Type }}(0)).Or().EqualTo({{ .Type }}(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 {{ end }}

--- a/validator_any.go
+++ b/validator_any.go
@@ -40,6 +40,22 @@ func (validator *ValidatorAny) Not() *ValidatorAny {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the string is equals "test".
+//	input := "test"
+//	isValid := v.Is(v.String(input).MinLength(5).Or().EqualTo("test")).Valid()
+func (validator *ValidatorAny) Or() *ValidatorAny {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if a value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/validator_any_test.go
+++ b/validator_any_test.go
@@ -135,3 +135,176 @@ func TestValidatorAnyPassingInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorAnyOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Any(true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Any(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Any(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Any(true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Any(true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Any(true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Any(true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Any(true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Any(true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Any(true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Any(true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Any(true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Any(true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorAnyOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Any(true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Any(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Any(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Any(true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Any(true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Any(true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Any(true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Any(true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Any(true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Any(true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Any(true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Any(true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Any(true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_boolean.go
+++ b/validator_boolean.go
@@ -58,6 +58,22 @@ func (validator *ValidatorBool[T]) Not() *ValidatorBool[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is equals false.
+//	input := true
+//	isValid := v.Is(v.Bool(input).False().Or().True()).Valid()
+func (validator *ValidatorBool[T]) Or() *ValidatorBool[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if a boolean value is equal to another.
 // For example:
 //

--- a/validator_boolean_p.go
+++ b/validator_boolean_p.go
@@ -37,6 +37,22 @@ func (validator *ValidatorBoolP[T]) Not() *ValidatorBoolP[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is equals false.
+//	input := true
+//	isValid := v.Is(v.BoolP(&input).Nil().Or().EqualTo(false)).Valid()
+func (validator *ValidatorBoolP[T]) Or() *ValidatorBoolP[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the value of a boolean pointer is equal to another value.
 // For example:
 //

--- a/validator_boolean_p_test.go
+++ b/validator_boolean_p_test.go
@@ -301,3 +301,176 @@ func TestValidatorBoolPInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorBoolPOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(BoolP(&_true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(BoolP(&_true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(BoolP(&_true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(BoolP(&_true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(BoolP(&_true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(BoolP(&_true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(BoolP(&_true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(BoolP(&_true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(BoolP(&_true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(BoolP(&_true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(BoolP(&_true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(BoolP(&_true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(BoolP(&_true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorBoolPOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(BoolP(&_true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(BoolP(&_true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(BoolP(&_true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(BoolP(&_true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(BoolP(&_true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(BoolP(&_true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(BoolP(&_true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(BoolP(&_true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(BoolP(&_true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(BoolP(&_true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(BoolP(&_true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(BoolP(&_true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(BoolP(&_true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_boolean_test.go
+++ b/validator_boolean_test.go
@@ -217,3 +217,176 @@ func TestValidatorBoolInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorBoolOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Bool(true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Bool(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Bool(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Bool(true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Bool(true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Bool(true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Bool(true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Bool(true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Bool(true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Bool(true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Bool(true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Bool(true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Bool(true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorBoolOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Bool(true).EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Bool(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Bool(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Bool(true).EqualTo(false).Or().EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Bool(true).EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Bool(true).Not().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Bool(true).Not().EqualTo(true).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Bool(true).EqualTo(true).Or().EqualTo(false).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Bool(true).EqualTo(false).Or().EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Bool(true).EqualTo(false).Or().EqualTo(true).EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Bool(true).EqualTo(false).Or().EqualTo(true).EqualTo(false))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Bool(true).EqualTo(true).EqualTo(true).Or().EqualTo(false))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Bool(true).EqualTo(true).EqualTo(false).Or().EqualTo(true))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_context.go
+++ b/validator_context.go
@@ -6,6 +6,8 @@ type validatorFragment struct {
 	templateParams map[string]any
 	function       func() bool
 	boolOperation  bool
+	orOperation    bool
+	isValid        bool
 }
 
 // The context keeps the state and provides the functions to control a
@@ -16,6 +18,7 @@ type ValidatorContext struct {
 	name          *string
 	title         *string
 	boolOperation bool
+	orOperation   bool
 }
 
 // Create a new [ValidatorContext] to be used by a custom validator.
@@ -25,6 +28,7 @@ func NewContext(value any, nameAndTitle ...string) *ValidatorContext {
 		value:         value,
 		fragments:     []*validatorFragment{},
 		boolOperation: true,
+		orOperation:   false,
 	}
 
 	sizeNameAndTitle := len(nameAndTitle)
@@ -44,6 +48,14 @@ func NewContext(value any, nameAndTitle ...string) *ValidatorContext {
 // a custom validator.
 func (ctx *ValidatorContext) Not() *ValidatorContext {
 	ctx.boolOperation = false
+	return ctx
+}
+
+// Add Or operation to validation.
+func (ctx *ValidatorContext) Or() *ValidatorContext {
+	if len(ctx.fragments) > 0 {
+		ctx.orOperation = true
+	}
 	return ctx
 }
 
@@ -75,12 +87,15 @@ func (ctx *ValidatorContext) AddWithParams(function func() bool, errorKey string
 		templateParams: templateParams,
 		function:       function,
 		boolOperation:  ctx.boolOperation,
+		orOperation:    ctx.orOperation,
+		isValid:        true,
 	}
 	if len(template) > 0 {
 		fragment.template = template
 	}
 	ctx.fragments = append(ctx.fragments, fragment)
 	ctx.boolOperation = true
+	ctx.orOperation = false
 
 	return ctx
 }
@@ -94,16 +109,47 @@ func (ctx *ValidatorContext) validateCheck(validation *Validation) *Validation {
 }
 
 func (ctx *ValidatorContext) validate(validation *Validation, shortCircuit bool) *Validation {
-	valid := true
+	// valid := true
 	validation.currentIndex++
 
+	// Iterating through each fragment in the context's fragment list
 	for i, fragment := range ctx.fragments {
-		if i > 0 && !valid && shortCircuit {
-			return validation
+
+		// If the previous fragment is not valid, the current fragment is not in an "or" operation, and the short circuit flag is true,
+		// we return the current state of the validation without evaluating the current fragment
+		if i > 0 && !ctx.fragments[i-1].isValid && !fragment.orOperation && shortCircuit {
+			break
 		}
 
-		valid = fragment.function() == fragment.boolOperation && valid
-		if !valid {
+		// If the current fragment is a part of an "or" operation and the previous fragment in the "or" operation
+		// is valid, we mark the current fragment as valid and move to the next iteration
+		if fragment.orOperation && ctx.fragments[i-1].isValid {
+			continue
+		}
+
+		// Evaluating the validation function of the current fragment and updating the valid flag
+		// The valid flag will be true only if the fragment function returns a value matching the fragment's boolean operation
+		// and the valid flag was true before this evaluation
+		fragment.isValid = fragment.function() == fragment.boolOperation
+
+		// If the current fragment is valid and is part of an "or" operation, we backtrack to mark all preceding
+		// fragments in the "or" operation chain as valid
+		if fragment.isValid && fragment.orOperation {
+			for j := i - 1; j >= 0; j-- {
+				ctx.fragments[j].isValid = true
+				// Breaking the loop when we reach the start of the "or" operation chain
+				if !ctx.fragments[j].orOperation {
+					break
+				}
+			}
+		}
+
+		// Setting the validation state of the current fragment
+		// valid = fragment.isValid && valid
+	}
+
+	for _, fragment := range ctx.fragments {
+		if !fragment.isValid {
 			validation.invalidate(ctx.name, fragment)
 		}
 	}

--- a/validator_number.gen.go
+++ b/validator_number.gen.go
@@ -68,6 +68,22 @@ func (validator *ValidatorUint8[T]) Not() *ValidatorUint8[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint8(0)
+//	isValid := v.Is(v.Uint8(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint8[T]) Or() *ValidatorUint8[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the uint8 value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -274,6 +290,22 @@ func (validator *ValidatorUint16[T]) Context() *ValidatorContext {
 //	Is(v.Uint16(uint16(0)).Not().Zero()).Valid()
 func (validator *ValidatorUint16[T]) Not() *ValidatorUint16[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint16(0)
+//	isValid := v.Is(v.Uint16(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint16[T]) Or() *ValidatorUint16[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -488,6 +520,22 @@ func (validator *ValidatorUint32[T]) Not() *ValidatorUint32[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint32(0)
+//	isValid := v.Is(v.Uint32(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint32[T]) Or() *ValidatorUint32[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the uint32 value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -694,6 +742,22 @@ func (validator *ValidatorUint64[T]) Context() *ValidatorContext {
 //	Is(v.Uint64(uint64(0)).Not().Zero()).Valid()
 func (validator *ValidatorUint64[T]) Not() *ValidatorUint64[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint64(0)
+//	isValid := v.Is(v.Uint64(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint64[T]) Or() *ValidatorUint64[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -908,6 +972,22 @@ func (validator *ValidatorInt[T]) Not() *ValidatorInt[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int(0)
+//	isValid := v.Is(v.Int(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt[T]) Or() *ValidatorInt[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1114,6 +1194,22 @@ func (validator *ValidatorInt8[T]) Context() *ValidatorContext {
 //	Is(v.Int8(int8(0)).Not().Zero()).Valid()
 func (validator *ValidatorInt8[T]) Not() *ValidatorInt8[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int8(0)
+//	isValid := v.Is(v.Int8(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt8[T]) Or() *ValidatorInt8[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -1328,6 +1424,22 @@ func (validator *ValidatorInt16[T]) Not() *ValidatorInt16[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int16(0)
+//	isValid := v.Is(v.Int16(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt16[T]) Or() *ValidatorInt16[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int16 value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1534,6 +1646,22 @@ func (validator *ValidatorInt32[T]) Context() *ValidatorContext {
 //	Is(v.Int32(int32(0)).Not().Zero()).Valid()
 func (validator *ValidatorInt32[T]) Not() *ValidatorInt32[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int32(0)
+//	isValid := v.Is(v.Int32(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt32[T]) Or() *ValidatorInt32[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -1748,6 +1876,22 @@ func (validator *ValidatorInt64[T]) Not() *ValidatorInt64[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int64(0)
+//	isValid := v.Is(v.Int64(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt64[T]) Or() *ValidatorInt64[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int64 value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1954,6 +2098,22 @@ func (validator *ValidatorFloat32[T]) Context() *ValidatorContext {
 //	Is(v.Float32(float32(0)).Not().Zero()).Valid()
 func (validator *ValidatorFloat32[T]) Not() *ValidatorFloat32[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := float32(0)
+//	isValid := v.Is(v.Float32(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorFloat32[T]) Or() *ValidatorFloat32[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -2168,6 +2328,22 @@ func (validator *ValidatorFloat64[T]) Not() *ValidatorFloat64[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := float64(0)
+//	isValid := v.Is(v.Float64(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorFloat64[T]) Or() *ValidatorFloat64[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the float64 value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -2378,6 +2554,22 @@ func (validator *ValidatorByte[T]) Not() *ValidatorByte[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := byte(0)
+//	isValid := v.Is(v.Byte(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorByte[T]) Or() *ValidatorByte[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the byte value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -2584,6 +2776,22 @@ func (validator *ValidatorRune[T]) Context() *ValidatorContext {
 //	Is(v.Rune(rune(0)).Not().Zero()).Valid()
 func (validator *ValidatorRune[T]) Not() *ValidatorRune[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := rune(0)
+//	isValid := v.Is(v.Rune(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorRune[T]) Or() *ValidatorRune[T] {
+	validator.context.Or()
 
 	return validator
 }

--- a/validator_number.go
+++ b/validator_number.go
@@ -92,6 +92,22 @@ func (validator *ValidatorNumber[T]) Not() *ValidatorNumber[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := 0
+//	isValid := v.Is(v.Number(input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorNumber[T]) Or() *ValidatorNumber[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if a numeric value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/validator_number_p.gen.go
+++ b/validator_number_p.gen.go
@@ -38,6 +38,22 @@ func (validator *ValidatorUint8P[T]) Not() *ValidatorUint8P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint8(0)
+//	isValid := v.Is(v.Uint8P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint8P[T]) Or() *ValidatorUint8P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the uint8 pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -249,6 +265,22 @@ func (validator *ValidatorUint16P[T]) Context() *ValidatorContext {
 //	Is(v.Uint16P(&n).Not().Zero()).Valid()
 func (validator *ValidatorUint16P[T]) Not() *ValidatorUint16P[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint16(0)
+//	isValid := v.Is(v.Uint16P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint16P[T]) Or() *ValidatorUint16P[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -468,6 +500,22 @@ func (validator *ValidatorUint32P[T]) Not() *ValidatorUint32P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint32(0)
+//	isValid := v.Is(v.Uint32P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint32P[T]) Or() *ValidatorUint32P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the uint32 pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -679,6 +727,22 @@ func (validator *ValidatorUint64P[T]) Context() *ValidatorContext {
 //	Is(v.Uint64P(&n).Not().Zero()).Valid()
 func (validator *ValidatorUint64P[T]) Not() *ValidatorUint64P[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := uint64(0)
+//	isValid := v.Is(v.Uint64P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorUint64P[T]) Or() *ValidatorUint64P[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -898,6 +962,22 @@ func (validator *ValidatorIntP[T]) Not() *ValidatorIntP[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int(0)
+//	isValid := v.Is(v.IntP(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorIntP[T]) Or() *ValidatorIntP[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1109,6 +1189,22 @@ func (validator *ValidatorInt8P[T]) Context() *ValidatorContext {
 //	Is(v.Int8P(&n).Not().Zero()).Valid()
 func (validator *ValidatorInt8P[T]) Not() *ValidatorInt8P[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int8(0)
+//	isValid := v.Is(v.Int8P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt8P[T]) Or() *ValidatorInt8P[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -1328,6 +1424,22 @@ func (validator *ValidatorInt16P[T]) Not() *ValidatorInt16P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int16(0)
+//	isValid := v.Is(v.Int16P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt16P[T]) Or() *ValidatorInt16P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int16 pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1539,6 +1651,22 @@ func (validator *ValidatorInt32P[T]) Context() *ValidatorContext {
 //	Is(v.Int32P(&n).Not().Zero()).Valid()
 func (validator *ValidatorInt32P[T]) Not() *ValidatorInt32P[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int32(0)
+//	isValid := v.Is(v.Int32P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt32P[T]) Or() *ValidatorInt32P[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -1758,6 +1886,22 @@ func (validator *ValidatorInt64P[T]) Not() *ValidatorInt64P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := int64(0)
+//	isValid := v.Is(v.Int64P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorInt64P[T]) Or() *ValidatorInt64P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the int64 pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -1969,6 +2113,22 @@ func (validator *ValidatorFloat32P[T]) Context() *ValidatorContext {
 //	Is(v.Float32P(&n).Not().Zero()).Valid()
 func (validator *ValidatorFloat32P[T]) Not() *ValidatorFloat32P[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := float32(0)
+//	isValid := v.Is(v.Float32P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorFloat32P[T]) Or() *ValidatorFloat32P[T] {
+	validator.context.Or()
 
 	return validator
 }
@@ -2188,6 +2348,22 @@ func (validator *ValidatorFloat64P[T]) Not() *ValidatorFloat64P[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := float64(0)
+//	isValid := v.Is(v.Float64P(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorFloat64P[T]) Or() *ValidatorFloat64P[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the float64 pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -2403,6 +2579,22 @@ func (validator *ValidatorByteP[T]) Not() *ValidatorByteP[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := byte(0)
+//	isValid := v.Is(v.ByteP(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorByteP[T]) Or() *ValidatorByteP[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the byte pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:
@@ -2614,6 +2806,22 @@ func (validator *ValidatorRuneP[T]) Context() *ValidatorContext {
 //	Is(v.RuneP(&n).Not().Zero()).Valid()
 func (validator *ValidatorRuneP[T]) Not() *ValidatorRuneP[T] {
 	validator.context.Not()
+
+	return validator
+}
+
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := rune(0)
+//	isValid := v.Is(v.RuneP(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorRuneP[T]) Or() *ValidatorRuneP[T] {
+	validator.context.Or()
 
 	return validator
 }

--- a/validator_number_p.go
+++ b/validator_number_p.go
@@ -40,6 +40,22 @@ func (validator *ValidatorNumberP[T]) Not() *ValidatorNumberP[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the input is Zero.
+//	input := 0
+//	isValid := v.Is(v.NumberP(&input).GreaterThan(5).Or().Zero()).Valid()
+func (validator *ValidatorNumberP[T]) Or() *ValidatorNumberP[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if a numeric pointer value is equal to another value. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/validator_number_p_test.gen.go
+++ b/validator_number_p_test.gen.go
@@ -597,6 +597,183 @@ func TestValidatorUint8PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint8POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = uint8(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint8P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint8P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint8P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint8P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint8P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint8P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint8P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint8P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint8P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint8P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint8P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint8POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = uint8(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint8P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint8P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint8P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint8P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint8P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint8P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint8P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint8P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint8P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint8P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint8P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint16PNot(t *testing.T) {
 
 	number1 := uint16(2)
@@ -1187,6 +1364,183 @@ func TestValidatorUint16PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint16POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = uint16(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint16P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint16P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint16P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint16P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint16P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint16P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint16P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint16P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint16P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint16P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint16P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint16POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = uint16(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint16P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint16P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint16P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint16P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint16P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint16P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint16P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint16P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint16P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint16P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint16P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint32PNot(t *testing.T) {
 
 	number1 := uint32(2)
@@ -1777,6 +2131,183 @@ func TestValidatorUint32PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint32POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = uint32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint32POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = uint32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint64PNot(t *testing.T) {
 
 	number1 := uint64(2)
@@ -2367,6 +2898,183 @@ func TestValidatorUint64PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint64POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = uint64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint64POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = uint64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorIntPNot(t *testing.T) {
 
 	number1 := int(2)
@@ -2957,6 +3665,183 @@ func TestValidatorIntPNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorIntPOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = int(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(IntP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(IntP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(IntP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(IntP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(IntP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(IntP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(IntP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(IntP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(IntP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(IntP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(IntP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(IntP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(IntP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorIntPOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = int(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(IntP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(IntP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(IntP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(IntP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(IntP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(IntP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(IntP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(IntP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(IntP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(IntP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(IntP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(IntP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(IntP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt8PNot(t *testing.T) {
 
 	number1 := int8(2)
@@ -3547,6 +4432,183 @@ func TestValidatorInt8PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt8POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = int8(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int8P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int8P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int8P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int8P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int8P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int8P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int8P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int8P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int8P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int8P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int8P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt8POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = int8(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int8P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int8P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int8P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int8P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int8P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int8P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int8P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int8P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int8P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int8P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int8P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int8P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt16PNot(t *testing.T) {
 
 	number1 := int16(2)
@@ -4137,6 +5199,183 @@ func TestValidatorInt16PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt16POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = int16(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int16P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int16P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int16P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int16P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int16P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int16P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int16P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int16P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int16P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int16P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int16P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt16POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = int16(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int16P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int16P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int16P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int16P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int16P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int16P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int16P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int16P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int16P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int16P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int16P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int16P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt32PNot(t *testing.T) {
 
 	number1 := int32(2)
@@ -4727,6 +5966,183 @@ func TestValidatorInt32PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt32POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = int32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt32POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = int32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt64PNot(t *testing.T) {
 
 	number1 := int64(2)
@@ -5317,6 +6733,183 @@ func TestValidatorInt64PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt64POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = int64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt64POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = int64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorFloat32PNot(t *testing.T) {
 
 	number1 := float32(2)
@@ -5907,6 +7500,183 @@ func TestValidatorFloat32PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorFloat32POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = float32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Float32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Float32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Float32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Float32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Float32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Float32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Float32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Float32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Float32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Float32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Float32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Float32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Float32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorFloat32POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = float32(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Float32P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Float32P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Float32P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Float32P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Float32P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Float32P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Float32P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Float32P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Float32P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Float32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Float32P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Float32P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Float32P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorFloat64PNot(t *testing.T) {
 
 	number1 := float64(2)
@@ -6497,6 +8267,183 @@ func TestValidatorFloat64PNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorFloat64POrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = float64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Float64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Float64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Float64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Float64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Float64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Float64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Float64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Float64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Float64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Float64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Float64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Float64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Float64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorFloat64POrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = float64(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Float64P(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Float64P(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Float64P(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Float64P(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Float64P(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Float64P(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Float64P(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Float64P(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Float64P(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Float64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Float64P(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Float64P(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Float64P(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorBytePNot(t *testing.T) {
 
 	number1 := byte(2)
@@ -7087,6 +9034,183 @@ func TestValidatorBytePNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorBytePOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = byte(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(ByteP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(ByteP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(ByteP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(ByteP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(ByteP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(ByteP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(ByteP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(ByteP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(ByteP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(ByteP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(ByteP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(ByteP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(ByteP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorBytePOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = byte(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(ByteP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(ByteP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(ByteP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(ByteP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(ByteP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(ByteP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(ByteP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(ByteP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(ByteP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(ByteP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(ByteP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(ByteP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(ByteP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorRunePNot(t *testing.T) {
 
 	number1 := rune(2)
@@ -7677,3 +9801,180 @@ func TestValidatorRunePNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorRunePOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = rune(1)
+
+	// Testing Or operation with two valid conditions
+	v = Is(RuneP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(RuneP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(RuneP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(RuneP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(RuneP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(RuneP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(RuneP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(RuneP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(RuneP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(RuneP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(RuneP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(RuneP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(RuneP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorRunePOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = rune(1)
+
+	// Testing Or operation with two valid conditions
+	v = Check(RuneP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(RuneP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(RuneP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(RuneP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(RuneP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(RuneP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(RuneP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(RuneP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(RuneP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(RuneP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(RuneP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(RuneP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(RuneP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+

--- a/validator_number_p_test.go
+++ b/validator_number_p_test.go
@@ -609,3 +609,179 @@ func TestValidatorNumberNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorNumberPOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+	var one = 1
+
+	// Testing Or operation with two valid conditions
+	v = Is(NumberP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(NumberP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(NumberP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(NumberP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(NumberP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(NumberP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(NumberP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(NumberP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(NumberP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(NumberP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(NumberP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(NumberP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(NumberP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorNumberPOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = 1
+
+	// Testing Or operation with two valid conditions
+	v = Check(NumberP(&one).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(NumberP(&one).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(NumberP(&one).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(NumberP(&one).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(NumberP(&one).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(NumberP(&one).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(NumberP(&one).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(NumberP(&one).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(NumberP(&one).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(NumberP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(NumberP(&one).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(NumberP(&one).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(NumberP(&one).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_number_test.gen.go
+++ b/validator_number_test.gen.go
@@ -388,6 +388,180 @@ func TestValidatorUint8InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint8OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint8(uint8(1)).Not().EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint8(uint8(1)).Not().EqualTo(uint8(1)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)).EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)).EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint8OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint8(uint8(1)).Not().EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint8(uint8(1)).Not().EqualTo(uint8(1)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)).EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)).EqualTo(uint8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(1)).Or().EqualTo(uint8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint8(uint8(1)).EqualTo(uint8(1)).EqualTo(uint8(0)).Or().EqualTo(uint8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint16Not(t *testing.T) {
 	v := Is(Uint16(uint16(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -769,6 +943,180 @@ func TestValidatorUint16InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint16OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint16(uint16(1)).Not().EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint16(uint16(1)).Not().EqualTo(uint16(1)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)).EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)).EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint16OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint16(uint16(1)).Not().EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint16(uint16(1)).Not().EqualTo(uint16(1)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)).EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)).EqualTo(uint16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(1)).Or().EqualTo(uint16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint16(uint16(1)).EqualTo(uint16(1)).EqualTo(uint16(0)).Or().EqualTo(uint16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint32Not(t *testing.T) {
 	v := Is(Uint32(uint32(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -1150,6 +1498,180 @@ func TestValidatorUint32InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint32OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint32(uint32(1)).Not().EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint32(uint32(1)).Not().EqualTo(uint32(1)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)).EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)).EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint32OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint32(uint32(1)).Not().EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint32(uint32(1)).Not().EqualTo(uint32(1)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)).EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)).EqualTo(uint32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(1)).Or().EqualTo(uint32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint32(uint32(1)).EqualTo(uint32(1)).EqualTo(uint32(0)).Or().EqualTo(uint32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorUint64Not(t *testing.T) {
 	v := Is(Uint64(uint64(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -1531,6 +2053,180 @@ func TestValidatorUint64InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorUint64OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Uint64(uint64(1)).Not().EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Uint64(uint64(1)).Not().EqualTo(uint64(1)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)).EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)).EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorUint64OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Uint64(uint64(1)).Not().EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Uint64(uint64(1)).Not().EqualTo(uint64(1)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)).EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)).EqualTo(uint64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(1)).Or().EqualTo(uint64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Uint64(uint64(1)).EqualTo(uint64(1)).EqualTo(uint64(0)).Or().EqualTo(uint64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorIntNot(t *testing.T) {
 	v := Is(Int(int(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -1912,6 +2608,180 @@ func TestValidatorIntInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorIntOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int(int(1)).EqualTo(int(1)).EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int(int(1)).Not().EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int(int(1)).Not().EqualTo(int(1)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)).EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)).EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int(int(1)).EqualTo(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int(int(1)).EqualTo(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorIntOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int(int(1)).EqualTo(int(1)).EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int(int(1)).Not().EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int(int(1)).Not().EqualTo(int(1)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)).EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)).EqualTo(int(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int(int(1)).EqualTo(int(1)).EqualTo(int(1)).Or().EqualTo(int(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int(int(1)).EqualTo(int(1)).EqualTo(int(0)).Or().EqualTo(int(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt8Not(t *testing.T) {
 	v := Is(Int8(int8(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -2293,6 +3163,180 @@ func TestValidatorInt8InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt8OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int8(int8(1)).Not().EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int8(int8(1)).Not().EqualTo(int8(1)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)).EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)).EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt8OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int8(int8(1)).Not().EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int8(int8(1)).Not().EqualTo(int8(1)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)).EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int8(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)).EqualTo(int8(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(1)).Or().EqualTo(int8(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int8(int8(1)).EqualTo(int8(1)).EqualTo(int8(0)).Or().EqualTo(int8(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt16Not(t *testing.T) {
 	v := Is(Int16(int16(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -2674,6 +3718,180 @@ func TestValidatorInt16InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt16OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int16(int16(1)).Not().EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int16(int16(1)).Not().EqualTo(int16(1)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)).EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)).EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt16OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int16(int16(1)).Not().EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int16(int16(1)).Not().EqualTo(int16(1)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)).EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int16(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)).EqualTo(int16(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(1)).Or().EqualTo(int16(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int16(int16(1)).EqualTo(int16(1)).EqualTo(int16(0)).Or().EqualTo(int16(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt32Not(t *testing.T) {
 	v := Is(Int32(int32(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -3055,6 +4273,180 @@ func TestValidatorInt32InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt32OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int32(int32(1)).Not().EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int32(int32(1)).Not().EqualTo(int32(1)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)).EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)).EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt32OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int32(int32(1)).Not().EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int32(int32(1)).Not().EqualTo(int32(1)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)).EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int32(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)).EqualTo(int32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(1)).Or().EqualTo(int32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int32(int32(1)).EqualTo(int32(1)).EqualTo(int32(0)).Or().EqualTo(int32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorInt64Not(t *testing.T) {
 	v := Is(Int64(int64(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -3436,6 +4828,180 @@ func TestValidatorInt64InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorInt64OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Int64(int64(1)).Not().EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Int64(int64(1)).Not().EqualTo(int64(1)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)).EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)).EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorInt64OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Int64(int64(1)).Not().EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Int64(int64(1)).Not().EqualTo(int64(1)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)).EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Int64(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)).EqualTo(int64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(1)).Or().EqualTo(int64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Int64(int64(1)).EqualTo(int64(1)).EqualTo(int64(0)).Or().EqualTo(int64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorFloat32Not(t *testing.T) {
 	v := Is(Float32(float32(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -3817,6 +5383,180 @@ func TestValidatorFloat32InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorFloat32OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Float32(float32(1)).Not().EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Float32(float32(1)).Not().EqualTo(float32(1)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)).EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)).EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorFloat32OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Float32(float32(1)).Not().EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Float32(float32(1)).Not().EqualTo(float32(1)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)).EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Float32(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)).EqualTo(float32(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(1)).Or().EqualTo(float32(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Float32(float32(1)).EqualTo(float32(1)).EqualTo(float32(0)).Or().EqualTo(float32(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorFloat64Not(t *testing.T) {
 	v := Is(Float64(float64(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -4198,6 +5938,180 @@ func TestValidatorFloat64InSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorFloat64OrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Float64(float64(1)).Not().EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Float64(float64(1)).Not().EqualTo(float64(1)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)).EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)).EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorFloat64OrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Float64(float64(1)).Not().EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Float64(float64(1)).Not().EqualTo(float64(1)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)).EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Float64(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)).EqualTo(float64(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(1)).Or().EqualTo(float64(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Float64(float64(1)).EqualTo(float64(1)).EqualTo(float64(0)).Or().EqualTo(float64(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorByteNot(t *testing.T) {
 	v := Is(Byte(byte(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -4579,6 +6493,180 @@ func TestValidatorByteInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorByteOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Byte(byte(1)).Not().EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Byte(byte(1)).Not().EqualTo(byte(1)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)).EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)).EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorByteOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Byte(byte(1)).Not().EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Byte(byte(1)).Not().EqualTo(byte(1)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)).EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Byte(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)).EqualTo(byte(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(1)).Or().EqualTo(byte(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Byte(byte(1)).EqualTo(byte(1)).EqualTo(byte(0)).Or().EqualTo(byte(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+
 func TestValidatorRuneNot(t *testing.T) {
 	v := Is(Rune(rune(1)).Not().EqualTo(2))
 	assert.True(t, v.Valid())
@@ -4960,3 +7048,177 @@ func TestValidatorRuneInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorRuneOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Rune(rune(1)).Not().EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Rune(rune(1)).Not().EqualTo(rune(1)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)).EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)).EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorRuneOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Rune(rune(1)).Not().EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Rune(rune(1)).Not().EqualTo(rune(1)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)).EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Rune(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)).EqualTo(rune(0)))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(1)).Or().EqualTo(rune(0)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Rune(rune(1)).EqualTo(rune(1)).EqualTo(rune(0)).Or().EqualTo(rune(1)))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}
+

--- a/validator_number_test.go
+++ b/validator_number_test.go
@@ -398,3 +398,176 @@ func TestValidatorNumberInSliceInvalid(t *testing.T) {
 		"Value 0 is not valid",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorNumberOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(Number(1).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Number(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Number(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Number(1).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Number(1).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Number(1).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Number(1).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Number(1).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Number(1).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Number(1).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Number(1).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Number(1).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Number(1).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorNumberOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(Number(1).EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Number(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Number(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Number(1).EqualTo(0).Or().EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Number(1).EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Number(1).Not().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Number(1).Not().EqualTo(1).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Number(1).EqualTo(1).Or().EqualTo(0).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Number(1).EqualTo(0).Or().EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Number(1).EqualTo(0).Or().EqualTo(1).EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Number(1).EqualTo(0).Or().EqualTo(1).EqualTo(0))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Number(1).EqualTo(1).EqualTo(1).Or().EqualTo(0))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Number(1).EqualTo(1).EqualTo(0).Or().EqualTo(1))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_string.go
+++ b/validator_string.go
@@ -91,6 +91,22 @@ func (validator *ValidatorString[T]) Not() *ValidatorString[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the string is equals "test".
+//	input := "test"
+//	isValid := v.Is(v.String(input).MinLength(5).Or().EqualTo("test")).Valid()
+func (validator *ValidatorString[T]) Or() *ValidatorString[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if a string value is equal to another. This function internally uses
 // the golang `==` operator.
 // For example:

--- a/validator_string_p.go
+++ b/validator_string_p.go
@@ -42,6 +42,22 @@ func (validator *ValidatorStringP[T]) Not() *ValidatorStringP[T] {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the string is equals "test".
+//	input := "test"
+//	isValid := v.Is(v.StringP(&input).MinLength(5).Or().EqualTo("test")).Valid()
+func (validator *ValidatorStringP[T]) Or() *ValidatorStringP[T] {
+	validator.context.Or()
+
+	return validator
+}
+
 // Validate if the value of a string pointer is equal to a another value.
 // For example:
 //

--- a/validator_string_p_test.go
+++ b/validator_string_p_test.go
@@ -1051,3 +1051,180 @@ func TestValidatorStringNilIsInvalid(t *testing.T) {
 		"Value 0 must be nil",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorStringPOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	var one = "1"
+
+	// Testing Or operation with two valid conditions
+	v = Is(StringP(&one).EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(StringP(&one).EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(StringP(&one).EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(StringP(&one).EqualTo("0").Or().EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(StringP(&one).EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(StringP(&one).Not().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(StringP(&one).Not().EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(StringP(&one).EqualTo("1").Or().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(StringP(&one).EqualTo("0").Or().EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(StringP(&one).EqualTo("0").Or().EqualTo("1").EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(StringP(&one).EqualTo("0").Or().EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(StringP(&one).EqualTo("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(StringP(&one).EqualTo("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorStringPOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	var one = "1"
+
+	// Testing Or operation with two valid conditions
+	v = Check(StringP(&one).EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(StringP(&one).EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(StringP(&one).EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(StringP(&one).EqualTo("0").Or().EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(StringP(&one).EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(StringP(&one).Not().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(StringP(&one).Not().EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(StringP(&one).EqualTo("1").Or().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(StringP(&one).EqualTo("0").Or().EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(StringP(&one).EqualTo("0").Or().EqualTo("1").EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(StringP(&one).EqualTo("0").Or().EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(StringP(&one).EqualTo("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(StringP(&one).EqualTo("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_string_test.go
+++ b/validator_string_test.go
@@ -655,3 +655,176 @@ func TestValidatorStringLengthBetweenInvalid(t *testing.T) {
 		"Value 0 must have a length between \"6\" and \"10\"",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorStringOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Is(String("1").EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(String("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(String("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(String("1").EqualTo("0").Or().EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(String("1").EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(String("1").Not().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(String("1").Not().EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(String("1").EqualTo("1").Or().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(String("1").EqualTo("0").Or().EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(String("1").EqualTo("0").Or().EqualTo("1").EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(String("1").EqualTo("0").Or().EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(String("1").EqualTo("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(String("1").EqualTo("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorStringOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	// Testing Or operation with two valid conditions
+	v = Check(String("1").EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(String("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(String("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(String("1").EqualTo("0").Or().EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(String("1").EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(String("1").Not().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(String("1").Not().EqualTo("1").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(String("1").EqualTo("1").Or().EqualTo("0").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(String("1").EqualTo("0").Or().EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(String("1").EqualTo("0").Or().EqualTo("1").EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(String("1").EqualTo("0").Or().EqualTo("1").EqualTo("0"))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(String("1").EqualTo("1").EqualTo("1").Or().EqualTo("0"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(String("1").EqualTo("1").EqualTo("0").Or().EqualTo("1"))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_time.go
+++ b/validator_time.go
@@ -81,6 +81,21 @@ func (validator *ValidatorTime) Not() *ValidatorTime {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the time is before or equal to time.Now().
+//	t := time.Now()
+//	isValid := v.Is(v.Time(t).Zero().Or().BeforeOrEqualTo(time.Now())).Valid()
+func (validator *ValidatorTime) Or() *ValidatorTime {
+	validator.context.Or()
+	return validator
+}
+
 // The EqualTo method validates if the time value is equal to another given time
 // value. It uses the equality (`==`) operator from Go for the comparison.
 //

--- a/validator_time_p.go
+++ b/validator_time_p.go
@@ -37,6 +37,21 @@ func (validator *ValidatorTimeP) Not() *ValidatorTimeP {
 	return validator
 }
 
+// Introduces a logical OR in the chain of validation conditions, affecting the
+// evaluation order and priority of subsequent validators. A value passes the
+// validation if it meets any one condition following the Or() call, adhering to
+// a left-to-right evaluation. This mechanism allows for validating against
+// multiple criteria where satisfying any single criterion is sufficient.
+// Example:
+//
+//	// This validator will pass because the time is before or equal to time.Now().
+//	t := time.Now()
+//	isValid := v.Is(v.TimeP(&t).Nil().Or().BeforeOrEqualTo(time.Now())).Valid()
+func (validator *ValidatorTimeP) Or() *ValidatorTimeP {
+	validator.context.Or()
+	return validator
+}
+
 // EqualTo validates that the time pointer is equal to the specified time value.
 //
 // Usage example:

--- a/validator_time_p_test.go
+++ b/validator_time_p_test.go
@@ -228,3 +228,182 @@ func TestValidatorPTimeZeroInvalid(t *testing.T) {
 		"Value 0 must be zero",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorTimePOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	timeZero := time.Time{}
+	timeOne := time.Time{}.Add(time.Second)
+
+	// Testing Or operation with two valid conditions
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(TimeP(&timeOne).Not().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(TimeP(&timeOne).Not().EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorTimePOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	timeZero := time.Time{}
+	timeOne := time.Time{}.Add(time.Second)
+
+	// Testing Or operation with two valid conditions
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(TimeP(&timeOne).Not().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(TimeP(&timeOne).Not().EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).Or().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(TimeP(&timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(TimeP(&timeOne).EqualTo(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}

--- a/validator_time_test.go
+++ b/validator_time_test.go
@@ -227,3 +227,182 @@ func TestValidatorTimeZeroInvalid(t *testing.T) {
 		"Value 0 must be zero",
 		v.Errors()["value_0"].Messages()[0])
 }
+
+func TestValidatorTimeOrOperatorWithIs(t *testing.T) {
+	var v *Validation
+
+	var _true = true
+	var _false = false
+
+	timeZero := time.Time{}
+	timeOne := time.Time{}.Add(time.Second)
+
+	// Testing Or operation with two valid conditions
+	v = Is(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Is(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Is(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Is(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Is(Time(timeOne).EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Is(Time(timeOne).Not().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Is(Time(timeOne).Not().EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Is(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Is(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Is(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Is(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Is(Time(timeOne).EqualTo(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Is(Time(timeOne).EqualTo(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+}
+
+func TestValidatorTimeOrOperatorWithCheck(t *testing.T) {
+	var v *Validation
+
+	// Check are Non-Short-circuited operations
+
+	var _true = true
+	var _false = false
+
+	timeZero := time.Time{}
+	timeOne := time.Time{}.Add(time.Second)
+
+	// Testing Or operation with two valid conditions
+	v = Check(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left invalid and right valid conditions
+	v = Check(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with left valid and right invalid conditions
+	v = Check(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing Or operation with two invalid conditions
+	v = Check(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, _false || false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing And operation (default when no Or() function is used) with left valid and right invalid conditions
+	v = Check(Time(timeOne).EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left valid and right invalid conditions
+	v = Check(Time(timeOne).Not().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing combination of Not and Or operators with left invalid and right valid conditions
+	v = Check(Time(timeOne).Not().EqualTo(timeOne).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, !true || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the first condition being valid
+	v = Check(Time(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true || _false || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing multiple Or operations in sequence with the last condition being valid
+	v = Check(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _false || false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid Or operation then valid And operation
+	v = Check(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, false || _true && true, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing valid Or operation then invalid And operation
+	v = Check(Time(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne).EqualTo(timeZero))
+	assert.False(t, v.Valid())
+	assert.Equal(t, false || true && false, v.Valid())
+	assert.NotEmpty(t, v.Errors())
+
+	// Testing valid And operation then invalid Or operation
+	v = Check(Time(timeOne).EqualTo(timeOne).EqualTo(timeOne).Or().EqualTo(timeZero))
+	assert.True(t, v.Valid())
+	assert.Equal(t, _true && true || false, v.Valid())
+	assert.Empty(t, v.Errors())
+
+	// Testing invalid And operation then valid Or operation
+	v = Check(Time(timeOne).EqualTo(timeOne).EqualTo(timeZero).Or().EqualTo(timeOne))
+	assert.True(t, v.Valid())
+	assert.Equal(t, true && false || true, v.Valid())
+	assert.Empty(t, v.Errors())
+}


### PR DESCRIPTION
# Or Operator in Validators

The `Or` operator function enables to combine validator rules using a logical OR chain. This addition allows for more nuanced validator scenarios, where a value may satisfy one of multiple conditions to be considered valid.

## Overview

In Valgo, validator rules are typically chained together using an implicit AND logic. This means that for a value to be deemed valid, it must satisfy all specified conditions. The `Or` operator provides an alternative by allowing conditions to be linked with OR logic. In such cases, a value is considered valid if it meets at least one of the chained conditions.

The `Or` operator follows a simple left-to-right boolean priority, akin to the Go language's approach to evaluating boolean expressions. Valgo does not have an equivalent to parentheses in API functions, in order to keep the syntax simple and readable. We believe that complex boolean logic becomes harder to read with a Fluent API interface, so for those cases, it is preferred to use imperative Go programming language constructs.

## Usage

To utilize the `Or` operator, simply insert `.Or().` between two conditions within your validator chain. Here's a basic example:

```go
v := Is(Bool(true).True().Or().False())
```

In this case, the validator passes because the boolean value `true` satisfies the first condition before the `Or()` operator.