### PR TITLE
Introducing Variadic Parameters to `Is` and `Check` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ package main
 import v "github.com/cohesivestack/valgo"
 
 func main() {
-  val := v.
-    Is(v.String("Bob", "full_name").Not().Blank().OfLengthBetween(4, 20)).
-    Is(v.Number(17, "age").GreaterThan(18))
+  val := v.Is(
+    v.String("Bob", "full_name").Not().Blank().OfLengthBetween(4, 20),
+    v.Number(17, "age").GreaterThan(18),
+  )
 
   if !val.Valid() {
     out, _ := json.MarshalIndent(val.Error(), "", "  ")
@@ -125,21 +126,22 @@ There are multiple functions to create a `Validation` session, depending on the 
 
 ## `Is(...)` function
 
-The `Is(...)` function allows you to pass a `Validator` with the value and the rules for validating it. At the same time, create a `Validation` session, which lets you add more Validators in order to verify more values.
+The `Is(...)` function allows you to pass one or multiple `Validator`s, each with their respective values and rules for validation. This creates a `Validation` session, which can be used to validate multiple values.
 
-As shown in the following example, we are passing to the function `Is(...)` the `Validator` for the `full_name` value. The function returns a `Validation` session that allows us to add more Validators to validate more values; in the example case the values `age` and `status`:
+
+In the following example, we pass multiple `Validator`s for the `full_name`, `age`, and `status` values to the `Is(...)` function:
 
 ```go
-val := v.
-  Is(v.String("Bob", "full_name").Not().Blank().OfLengthBetween(4, 20)).
-  Is(v.Number(17, "age").GreaterThan(18)).
-  Is(v.String("singl", "status").InSlice([]string{"married", "single"}))
+val := v.Is(
+  v.String("Bob", "full_name").Not().Blank().OfLengthBetween(4, 20),
+  v.Number(17, "age").GreaterThan(18),
+  v.String("singl", "status").InSlice([]string{"married", "single"})
+)
 
 if !val.Valid() {
   out, _ := json.MarshalIndent(val.Error(), "", "  ")
   fmt.Println(string(out))
 }
-```
 output:
 ```json
 {
@@ -162,8 +164,10 @@ A `Validation` session provide this function, which returns either `true` if all
 In the following example, even though the Validator for `age` is valid, the `Validator` for `status` is invalid, making the entire `Validator` session invalid.
 
 ```go
-val := v.Is(v.Number(21, "age").GreaterThan(18)).
-  Is(v.String("singl", "status").InSlice([]string{"married", "single"}))
+val := v.Is(
+  v.Number(21, "age").GreaterThan(18),
+  v.String("singl", "status").InSlice([]string{"married", "single"}),
+)
 
 if !val.Valid() {
   out, _ := json.MarshalIndent(val.Error(), "", "  ")
@@ -219,9 +223,10 @@ p := Person{"Bob", Address{"", "1600 Amphitheatre Pkwy"}}
 
 val := v.
   Is(v.String(p.Name, "name").OfLengthBetween(4, 20)).
-  In("address",
-    Is(String(p.Address.Name, "name").Not().Blank()).
-    Is(String(p.Address.Street, "street").Not().Blank()))
+  In("address", v.Is(
+    String(p.Address.Name, "name").Not().Blank(),
+    String(p.Address.Street, "street").Not().Blank(),
+  ))
 
 if !val.Valid() {
   out, _ := json.MarshalIndent(val.Error(), "", "  ")
@@ -269,9 +274,10 @@ p := Person{
 val := v.Is(String(p.Name, "name").OfLengthBetween(4, 20))
 
 for i, a := range p.Addresses {
-  val.InRow("addresses", i,
-    v.Is(v.String(a.Name, "name").Not().Blank()).
-    v.Is(v.String(a.Street, "street").Not().Blank()))
+  val.InRow("addresses", i, v.Is(
+    v.String(a.Name, "name").Not().Blank(),
+    v.String(a.Street, "street").Not().Blank(),
+  ))
 }
 
 if !val.Valid() {
@@ -334,9 +340,10 @@ type Address struct {
 
 a := Address{"", "1600 Amphitheatre Pkwy"}
 
-val := v.
-  Is(String(a.city, "city").Not().Blank()).
-  Is(String(a.Street, "street").Not().Blank())
+val := v.Is(
+  v.String(a.city, "city").Not().Blank(),
+  v.String(a.Street, "street").Not().Blank(),
+)
 
 if !val.Valid() {
   v.AddErrorMessage("address", "The address is wrong!")
@@ -382,9 +389,10 @@ validatePreStatus := func(status string) *Validation {
 
 r := Record{"Classified", ""}
 
-val := v.
-  Is(v.String(r.Name, "name").Not().Blank()).
-  Is(v.String(r.Status, "status").Not().Blank())
+val := v.Is(
+  v.String(r.Name, "name").Not().Blank(),
+  v.String(r.Status, "status").Not().Blank(),
+)
 
 val.Merge(validatePreStatus(r.Status))
 
@@ -525,9 +533,10 @@ There are two options for localization: `localeCode` and `locale`. Below, we lis
   })
 
   // Testing the output
-  val := val.
-    Is(v.String(" ", "name").Not().Blank()).
-    Is(v.Bool(false, "active").Not().False())
+  val := val.Is(
+    v.String(" ", "name").Not().Blank(),
+    v.Bool(false, "active").Not().False(),
+  )
 
   out, _ := json.MarshalIndent(val.Error(), "", "  ")
   fmt.Println(string(out))
@@ -724,7 +733,7 @@ x := "Rust";           v.Is(v.StringP(&x).Between("Go", "Typescript")) // Inclus
 x := "";               v.Is(v.StringP(&x).Empty())
 x := " ";              v.Is(v.StringP(&x).Blank())
 x := "Dart";           v.Is(v.StringP(&x).Passing(func(val *string) bool { return *val == "Dart" }))
-x := "processing";     v.Is(v.StringP(&x).InSlice([]string{"idle", "processing", "ready"})
+x := "processing";     v.Is(v.StringP(&x).InSlice([]string{"idle", "processing", "ready"}))
 x := "123456";         v.Is(v.StringP(&x).MaxLength(6))
 x := "123";            v.Is(v.StringP(&x).MinLength(3))
 x := "1234";           v.Is(v.StringP(&x).MinLength(4))

--- a/valgo.go
+++ b/valgo.go
@@ -80,8 +80,8 @@ func New(options ...Options) *Validation {
 // the [Validator] for the full_name value. The function returns a [Validation]
 // session that allows us to add more Validators to validate more values; in the
 // example case the values age and status:
-func Is(v Validator) *Validation {
-	return New().Is(v)
+func Is(validators ...Validator) *Validation {
+	return New().Is(validators...)
 }
 
 // The [In](...) function executes one or more validators in a namespace, so the
@@ -115,8 +115,8 @@ func InRow(name string, index int, v *Validation) *Validation {
 // This example shows two rules that fail due to the empty value in the full_name
 // [Validator], and since the [Validator] is not short-circuited, both error
 // messages are added to the error result.
-func Check(v Validator) *Validation {
-	return New().Check(v)
+func Check(validators ...Validator) *Validation {
+	return New().Check(validators...)
 }
 
 // Create a new [Validation] session and add an error message to it without

--- a/validation.go
+++ b/validation.go
@@ -54,14 +54,20 @@ type Options struct {
 }
 
 // Add a field validator to a [Validation] session.
-func (validation *Validation) Is(v Validator) *Validation {
-	return v.Context().validateIs(validation)
+func (validation *Validation) Is(validators ...Validator) *Validation {
+	for _, v := range validators {
+		validation = v.Context().validateIs(validation)
+	}
+	return validation
 }
 
 // Add a field validator to a [Validation] session. But unlike [Is()] the
 // field validator is not short-circuited.
-func (validation *Validation) Check(v Validator) *Validation {
-	return v.Context().validateCheck(validation)
+func (validation *Validation) Check(validators ...Validator) *Validation {
+	for _, v := range validators {
+		validation = v.Context().validateCheck(validation)
+	}
+	return validation
 }
 
 // A [Validation] session provides this function which returns either true if

--- a/validation.go
+++ b/validation.go
@@ -53,7 +53,7 @@ type Options struct {
 	MarshalJsonFunc func(e *Error) ([]byte, error)
 }
 
-// Add a field validator to a [Validation] session.
+// Add one or more validators to a [Validation] session.
 func (validation *Validation) Is(validators ...Validator) *Validation {
 	for _, v := range validators {
 		validation = v.Context().validateIs(validation)
@@ -61,8 +61,8 @@ func (validation *Validation) Is(validators ...Validator) *Validation {
 	return validation
 }
 
-// Add a field validator to a [Validation] session. But unlike [Is()] the
-// field validator is not short-circuited.
+// Add one or more validators to a [Validation] session. But unlike [Is()],
+// the validators are not short-circuited.
 func (validation *Validation) Check(validators ...Validator) *Validation {
 	for _, v := range validators {
 		validation = v.Context().validateCheck(validation)


### PR DESCRIPTION
The update to Valgo's `Is(...)` and `Check(...)` functions, introducing variadic parameters, significantly streamlines validation syntax by reducing verbosity and enhancing modularity. This allows for multiple `Validators` in a single call, simplifying code and enabling the reuse of validator groups for consistent validation across an application. It cuts down boilerplate, promotes cleaner code, and facilitates complex validation strategies with ease.