### PR TITLE
Simplify CI to Ubuntu-only testing.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x]
-        platform: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Fetch Git Repository


### PR DESCRIPTION
This change focuses the CI Test job exclusively on the Ubuntu platform. Given Valgo's reliance on Go's standard library and its independence from operating system-specific functionalities.

This adjustment makes our CI process more efficient, reducing resource consumption and build times without compromising the reliability or coverage of our tests. It reflects our confidence in Go's cross-platform compatibility for projects like ours that primarily utilize language features and standard libraries.

This decision will be revisited periodically to ensure it continues to align with the project's evolution and requirements.