### PR TITLE
Feature/new error functions

### DIFF
--- a/validation_test.go
+++ b/validation_test.go
@@ -300,7 +300,7 @@ func TestValidationMergeError(t *testing.T) {
 		v1.Errors()["name"].Messages()[0])
 
 	// v0 is initially valid, but merging to v1 must be invalidated
-	v0.MergeError(v1.Error().(*Error))
+	v0.MergeError(v1.ToValgoError())
 
 	assert.False(t, v0.Valid())
 	assert.Equal(t,
@@ -326,7 +326,7 @@ func TestValidationMergeError(t *testing.T) {
 		v1.Errors()["status"].Messages()[0])
 
 	// v0 is initially valid, but merging to v1 must be invalidated
-	v0.MergeError(v1.Error().(*Error))
+	v0.MergeError(v1.ToValgoError())
 
 	assert.False(t, v0.IsValid("status"))
 	assert.Equal(t,
@@ -363,7 +363,7 @@ func TestValidationMergeErrorIn(t *testing.T) {
 		v1.Errors()["lastName"].Messages()[0])
 
 	// v0 is initially valid, but merging to v1 Errors must be invalidated
-	v0.MergeErrorIn("user", v1.Error().(*Error))
+	v0.MergeErrorIn("user", v1.ToValgoError())
 
 	assert.False(t, v0.Valid())
 	assert.Equal(t,
@@ -391,10 +391,10 @@ func TestValidationMergeErrorInRow(t *testing.T) {
 		v1.Errors()["name"].Messages()[0])
 
 	// v0 is initially valid, but merging to v1 Errors must be invalidated
-	v0.MergeErrorInRow("user", 0, v1.Error().(*Error))
+	v0.MergeErrorInRow("user", 0, v1.ToValgoError())
 
 	// v0 is initially valid, but merging to v1 Errors must be invalidated
-	v0.MergeErrorInRow("user", 1, v1.Error().(*Error))
+	v0.MergeErrorInRow("user", 1, v1.ToValgoError())
 
 	assert.False(t, v0.Valid())
 	assert.Equal(t,


### PR DESCRIPTION
## PR Description

# Improve Error Handling API and Documentation

## Overview

Addresses [#14](https://github.com/cohesivestack/valgo/issues/14) by introducing new error handling functions while maintaining backward compatibility.

## Changes

### New API
- **`ToError()`**: Returns standard Go `error` interface for idiomatic error handling
- **`ToValgoError()`**: Returns concrete `*valgo.Error` type for detailed error information  
- **`Error()`**: Deprecated (will be removed in v1)

### Why?
- Original `Error()` conflicted with Go's error interface convention
- `To` prefix is more idiomatic and indicates transformation
- `ToValgoError()` is a shortcut to `ToError().(*valgo.Error)`

### Documentation
- Updated all README examples to use `ToError()`
- Added comprehensive error handling section with usage guidance
- Updated table of contents and terminology

### Tests
- Added tests for deprecated function compatibility
- Added tests verifying both new functions return same underlying error
- Updated existing tests to use new API

## Migration

```go
// Old (deprecated)
val.Error()

// New (recommended)
val.ToError()        // Standard error handling
val.ToValgoError()   // Detailed error information
```

## Benefits
- ✅ Solves Issue #14 (detailed field errors instead of "There is 1 error")
- ✅ Better Go idioms and API clarity
- ✅ Backward compatible with clear deprecation path

Closes [#14](https://github.com/cohesivestack/valgo/issues/14)